### PR TITLE
add config fixtures and types

### DIFF
--- a/src/automation.ts
+++ b/src/automation.ts
@@ -17,6 +17,27 @@ interface AutomationProps {
   url: string;
 }
 
+interface SimpleConfig {
+  'leading-steps': Array<string>;
+  'action-steps': { [step: string]: string };
+}
+
+interface AdvancedConfig {
+  config?: {
+    cookies: {
+      [cookie: string]: string;
+    };
+    headers: {
+      [header: string]: string;
+    };
+  };
+  pages: {
+    [page: string]: SimpleConfig;
+  };
+}
+
+type Config = AdvancedConfig | SimpleConfig;
+
 type Flows = {
   [key: string]: string[];
 };

--- a/test/fixtures/configs/advanced/react.automation.js
+++ b/test/fixtures/configs/advanced/react.automation.js
@@ -1,0 +1,33 @@
+export default {
+  automation: {
+    pages: {
+      'authenticate-with-cookie': {
+        'leading-steps': [], // can be omitted
+        'action-steps': {}, // can be omitted
+      },
+      'three-buttons': {
+        'leading-steps': [], // can be omitted
+        'action-steps': {
+          'Click First Button': ['click .first-button'],
+          'Click Second Button Twice': [
+            'click .second-button',
+            'click .second-button',
+          ],
+          'Click Third Button Three Times': [
+            'click .third-button',
+            'click .third-button',
+            'click .third-button',
+          ],
+        },
+      },
+    },
+  },
+  config: {
+    cookies: {
+      auth: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+    },
+    headers: {
+      Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l',
+    },
+  },
+};

--- a/test/fixtures/configs/advanced/react.automation.json
+++ b/test/fixtures/configs/advanced/react.automation.json
@@ -1,0 +1,33 @@
+{
+  "automation": {
+    "pages": {
+      "authenticate-with-cookie": {
+        "leading-steps": [],
+        "action-steps": {}
+      },
+      "three-buttons": {
+        "leading-steps": [],
+        "action-steps": {
+          "Click First Button": ["click .first-button"],
+          "Click Second Button Twice": [
+            "click .second-button",
+            "click .second-button"
+          ],
+          "Click Third Button Three Times": [
+            "click .third-button",
+            "click .third-button",
+            "click .third-button"
+          ]
+        }
+      }
+    }
+  },
+  "config": {
+    "cookies": {
+      "auth": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    },
+    "headers": {
+      "Authorization": "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+    }
+  }
+}

--- a/test/fixtures/configs/advanced/react.automation.yml
+++ b/test/fixtures/configs/advanced/react.automation.yml
@@ -1,0 +1,22 @@
+automation:
+  pages:
+    authenticate-with-cookie:
+      leading-steps: [] # can be omitted
+      action-steps: {} # can be omitted
+    three-buttons:
+      leading-steps: [] # can be omitted
+      action-steps:
+        Click First Button:
+          - click .first-button
+        Click Second Button Twice:
+          - click .second-button
+          - click .second-button
+        Click Third Button Three Times:
+          - click .third-button
+          - click .third-button
+          - click .third-button
+config:
+  cookies:
+    auth: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+  headers:
+    Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l

--- a/test/fixtures/configs/simple/react.automation.js
+++ b/test/fixtures/configs/simple/react.automation.js
@@ -1,0 +1,15 @@
+export default {
+  'leading-steps': [], // can be omitted
+  'action-steps': {
+    'Click First Button': ['click .first-button'],
+    'Click Second Button Twice': [
+      'click .second-button',
+      'click .second-button',
+    ],
+    'Click Third Button Three Times': [
+      'click .third-button',
+      'click .third-button',
+      'click .third-button',
+    ],
+  },
+};

--- a/test/fixtures/configs/simple/react.automation.json
+++ b/test/fixtures/configs/simple/react.automation.json
@@ -1,0 +1,15 @@
+{
+  "leading-steps": [],
+  "action-steps": {
+    "Click First Button": ["click .first-button"],
+    "Click Second Button Twice": [
+      "click .second-button",
+      "click .second-button"
+    ],
+    "Click Third Button Three Times": [
+      "click .third-button",
+      "click .third-button",
+      "click .third-button"
+    ]
+  }
+}

--- a/test/fixtures/configs/simple/react.automation.yml
+++ b/test/fixtures/configs/simple/react.automation.yml
@@ -1,0 +1,14 @@
+leading-steps:
+  - type .login-username rpivo
+  - type .login-password 123abc
+  - click .submit
+action-steps:
+  Click First Button:
+    - click .first-button
+  Click Second Button:
+    - click .second-button
+    - click .second-button
+  Click Third Button:
+    - click .third-button
+    - click .third-button
+    - click .third-button


### PR DESCRIPTION
This PR adds some example configs to a `test` folder which can eventually be used for tests. Currently react-automation-profiler only accepts yaml, but it might be nice to also accept either json or a regular js module.

In prepping for `leading-steps`, or being able to accept headers or cookies up front for automation flows, the react-automation-profiler config needs to be able to hold more information than just action steps.

test/fixtures/configs/simple/react.automation.yml is what react-automation-profiler currently can ingest (except for leading-steps).

test/fixtures/configs/advanced/react.automation.yml is an "advanced" config, which has two properties at the top level: `config` and `pages`. `pages` is a list of pages each with their own automation flows. This could be useful if later on if react-automation-profiler can either run automation flows for *all* pages, or just a specific page.

Ex: the snippet below has automation steps for two different pages, "example.com/some-page" and "example.com/another-page".

The `config` property can contain config info that can be passed to react-automation-profiler up front before running automation, like headers or cookies that are needed to run the automation. We can also store react-automation-profiler's CLI flags here rather than passing them in on the command line (ex: the `includeMount` flag is set in the example below).

```yml
automation:
  pages:
    some-page: {}
    another-page:
      leading-steps: []
      Click First Button:
        - click .first-button
      Click Second Button Twice:
        - click .second-button
        - click .second-button
      Click Third Button Three Times:
        - click .third-button
        - click .third-button
        - click .third-button
config:
  cookies:
    auth: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
  headers:
    Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
  includeMount: false
```

In `automation.ts`, I defined the types for both of these configs as `AdvancedConfig` and `SimpleConfig`. I kind of like the idea that either of these configs could be passed to react-automation-profiler, but I also don't want this to be confusing.

<hr/>

What do you think? Would you change the advanced config somehow?

Out of headers, cookies, and leading-steps, which would be the most useful right now?

